### PR TITLE
Fixes #4 by cleaning up code and adding listener in uCookie.js regardless if cmp locator is found

### DIFF
--- a/src/content_scripts/uCookie.js
+++ b/src/content_scripts/uCookie.js
@@ -98,7 +98,7 @@ const foundCmpFrame = setUpCmpWrapper();
 
 function callPopupJs(request, sender, sendResponseToPopupJs) {
   // respond to query checking whether there is a __tcfapiLocator iframe
-  if (request.check_cmp_frame === 'looking for __tcfapiLocator') {
+  if (request.checkCmpFrame === 'looking for __tcfapiLocator') {
     if (foundCmpFrame) {
       sendResponseToPopupJs({ response: 'found' });
     } else {

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -23,7 +23,7 @@ function fetchData() {
     }
     try {
       if (!cmpLocatorFound) {
-        message = { check_cmp_frame: 'looking for __tcfapiLocator' };
+        message = { checkCmpFrame: 'looking for __tcfapiLocator' };
       } else {
         message = { call: 'getTCData', manual: false };
       }
@@ -65,21 +65,21 @@ function handleResponseFromUCookieJs(message) {
     }
     return;
   }
-
   if (res.tcData) {
-    if (res.tcData.gdprApplies === false) {
+    const { gdprApplies, tcString, consentData } = res.tcData;
+    if (gdprApplies === false) {
       document.getElementById('gdpr_applies_false').classList.remove('hidden');
       document.getElementById('cmplocator_found').classList.add('hidden');
     }
     console.log(res);
-    if (res.tcData.tcString) {
-      consent_string = decodeConsentString(res.tcData.tcString);
+    if (tcString) {
+      consent_string = decodeConsentString(tcString);
     }
     const validCs = update_with_consent_string_data(consent_string);
     if (!validCs) {
       return;
     }
-    if (res.tcData.consentData) {
+    if (consentData) {
       document.getElementById('show_cs').classList.remove('hidden');
       document.getElementById('manual_cs').classList.add('hidden');
       document.getElementById('consent_string').textContent = res.tcData.consentData;


### PR DESCRIPTION
Observed that the appropriate messages still show up on lemonde.fr, indicating that this hasn't introduced a regression. Also added some logging to validate the expected code paths were hit (removed that logging for the PR).

Main change is that we setup the listener in uCookie.js regardless if the cmpLocator was found. In the case that it isn't found, then we can respond to popup.js that no cmpLocator is present so that the popup.js can stop querying fetchData. The functionality doesn't change much, but the code flow is hopefully easier to follow.

Other changes related to styling.