### PR TITLE
[issue #17] refactor connections; set up storage

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1,7 +1,11 @@
 /* global chrome */
 /* global browser */
 import {
-  API_MSG, GET_TC_DATA_CALL, LOOKING_FOR_LOCATOR_MSG, NOT_FOUND_MSG, FOUND_MSG,
+  API_MSG,
+  GET_TC_DATA_CALL,
+  LOOKING_FOR_LOCATOR_MSG,
+  NOT_FOUND_MSG,
+  FOUND_MSG,
 } from '../content_scripts/uCookie';
 
 let api;
@@ -14,23 +18,16 @@ if (chrome === undefined) {
   api = chrome;
 }
 
-function fetchData(port) {
-  let message;
+function askForCmpFrame(port) {
   try {
-    if (!cmpLocatorFound) {
-      message = { message: LOOKING_FOR_LOCATOR_MSG };
-    } else {
-      message = { message: API_MSG, api: GET_TC_DATA_CALL, manual: false };
-    }
-
     // send message to uCookie.js
-    port.postMessage(message);
+    port.postMessage({ message: LOOKING_FOR_LOCATOR_MSG });
   } catch (error) {
     console.log('background.js: error caught', error);
   }
 }
 
-function handleMessageFromUCookie(message) {
+function handleMessageFromUCookie(message, port) {
   if (!message || !message.response) { return; }
   const { response } = message;
   try {
@@ -38,42 +35,87 @@ function handleMessageFromUCookie(message) {
       case NOT_FOUND_MSG:
       // TODO: show user that this page does not implement TCF
       // CMP iframe isn't present on this page so stop calling fetchData
-        window.clearInterval(fetchDataIntervalId);
         break;
       case FOUND_MSG:
-        cmpLocatorFound = true;
-
-        // TODO:
-        // - update UI that cmp was found
+        // uCookie found the tcfapiLocator frame
+        // send a message back asking for the TC Data
+        port.postMessage({ message: API_MSG, api: GET_TC_DATA_CALL, manual: false });
         break;
       case GET_TC_DATA_CALL:
       // TODO:  write function to handle getTCData response
-        console.log('received tcData!', message.data);
+        console.log('received tcData!', message);
+
         break;
       default:
         console.log('[background.js] Unknown response: ', response);
     }
   } catch (error) {
     console.log('Error handling message: ', error);
-    window.clearInterval(fetchDataIntervalId);
   }
 }
 
 function handleDisconnect(port) {
   // TODO: show an error to the user if the port was disconnected
-  console.log('[background.js] Port was closed', port);
+  console.log('[background.js] Port was closed', port.name);
 }
+
+let contentScriptPort;
+api.tabs.onActivated.addListener(() => {
+  console.log('switched tabs!');
+  cmpLocatorFound = false;
+
+  if (contentScriptPort) {
+    console.log('disconnecting port', contentScriptPort);
+    contentScriptPort.disconnect();
+  }
+
+  api.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    // set up a connection with the active tab's content script (uCookie)
+    contentScriptPort = api.tabs.connect(tabs[0].id, { name: String(tabs[0].id) });
+    console.log('connected to port: ', contentScriptPort);
+
+    // ask if the cmp frame has been located
+    askForCmpFrame(contentScriptPort);
+
+    contentScriptPort.onMessage.addListener((message) => {
+      handleMessageFromUCookie(message, contentScriptPort);
+    });
+    contentScriptPort.onDisconnect.addListener(handleDisconnect);
+  });
+});
 
 // Once the we connect to the port, start pinging the
 // content script (uCookie.js) to let us know if the API locator
 // frame was found and we can start fetching TC data
-api.runtime.onConnect.addListener((port) => {
-  fetchData(port);
+// api.runtime.onConnect.addListener((port) => {
+//   console.log('port name', port);
 
-  fetchDataIntervalId = window.setInterval(() => {
-    fetchData(port);
-  }, 5000);
+//   if (port.name === 'uCookie') {
+//     fetchData(port);
 
-  port.onDisconnect.addListener(handleDisconnect);
-  port.onMessage.addListener(handleMessageFromUCookie);
-});
+//     fetchDataIntervalId = window.setInterval(() => {
+//       fetchData(port);
+//     }, 5000);
+
+//     port.onMessage.addListener(handleMessageFromUCookie);
+//   } else if (port.name === 'popup') {
+//     popupPort = port;
+//     port.onMessage.addListener(handleMessageFromPopup);
+//   } else {
+//     return;
+//   }
+
+//   window.setInterval(() => {
+//     api.storage.local.set({ test: 'bye' });
+//   }, 10000);
+
+//   port.onDisconnect.addListener(handleDisconnect);
+// });
+
+// api.extension.onConnect.addListener((port) => {
+//   console.log('port name::::', port.name);
+//   port.onMessage.addListener((msg) => {
+//     console.log(`message recieved ${msg}`);
+//     port.postMessage('Hi Popup.js');
+//   });
+// });

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -9,8 +9,6 @@ import {
 } from '../content_scripts/uCookie';
 
 let api;
-let cmpLocatorFound = false;
-let fetchDataIntervalId;
 
 if (chrome === undefined) {
   api = browser;
@@ -34,12 +32,12 @@ function handleMessageFromUCookie(message, port) {
     switch (response) {
       case NOT_FOUND_MSG:
       // TODO: show user that this page does not implement TCF
-      // CMP iframe isn't present on this page so stop calling fetchData
         break;
       case FOUND_MSG:
         // uCookie found the tcfapiLocator frame
         // send a message back asking for the TC Data
         port.postMessage({ message: API_MSG, api: GET_TC_DATA_CALL, manual: false });
+        // TODO: update ucookie.html
         break;
       case GET_TC_DATA_CALL:
       // TODO:  write function to handle getTCData response
@@ -62,7 +60,6 @@ function handleDisconnect(port) {
 let contentScriptPort;
 api.tabs.onActivated.addListener(() => {
   console.log('switched tabs!');
-  cmpLocatorFound = false;
 
   if (contentScriptPort) {
     console.log('disconnecting port', contentScriptPort);

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -11,6 +11,7 @@ import '../button/38_green.png';
 import '../button/38_red.png';
 import '../button/38.png';
 import './ucookie.css';
+import { TCString } from '@iabtcf/core';
 
 let api;
 if (chrome === undefined) {
@@ -19,6 +20,69 @@ if (chrome === undefined) {
   api = chrome;
 }
 
+function handleCmpLocatorFound(cmpLocatorFound) {
+  try {
+    if (cmpLocatorFound === true) {
+      document.getElementById('nothing_found').classList.add('hidden');
+      document.getElementById('cmplocator_found').classList.remove('hidden');
+    } else {
+      document.getElementById('nothing_found').classList.remove('hidden');
+      document.getElementById('cmplocator_found').classList.add('hidden');
+    }
+  } catch {
+    // popup not open
+  }
+}
+
+function handleGdprApplies(gdprApplies) {
+  try {
+    if (gdprApplies === true) {
+      document.getElementById('gdpr_applies_false').classList.add('hidden');
+      document.getElementById('cmplocator_found').classList.remove('hidden');
+    } else {
+      document.getElementById('gdpr_applies_false').classList.remove('hidden');
+      document.getElementById('cmplocator_found').classList.add('hidden');
+    }
+  } catch {
+    // popup not open
+  }
+}
+
+function getActiveTabStorage() {
+  api.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    const activeTabId = tabs[0].id;
+    console.log('active tab id', tabs[0].id);
+
+    api.storage.local.get([String(activeTabId)], (result) => {
+      const data = result[activeTabId];
+      console.log('data from storage', data);
+
+      // we've confirmed if the tcfapiLocator has been found
+      if (data.found !== undefined) {
+        handleCmpLocatorFound(data.found);
+      } else {
+        return;
+      }
+
+      if (data.gdprApplies !== undefined) {
+        handleGdprApplies(data.gdprApplies);
+      }
+
+      // tcfapiLocator has been found & received tcString
+      if (data.found === true && data.tcString !== undefined) {
+        console.log('decoded string', TCString.decode(data.tcString));
+      }
+    });
+  });
+}
+
+window.setInterval(() => {
+  getActiveTabStorage();
+}, 5000);
+
+getActiveTabStorage();
+
+// ----------------------------- OLD LOGIC -----------------------------
 let cmpLocatorFound = false;
 let vendorListVersion = 2;
 let consentString = null;

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -76,10 +76,6 @@ function getActiveTabStorage() {
   });
 }
 
-window.setInterval(() => {
-  getActiveTabStorage();
-}, 5000);
-
 getActiveTabStorage();
 
 // ----------------------------- OLD LOGIC -----------------------------

--- a/src/popup/ucookie.html
+++ b/src/popup/ucookie.html
@@ -12,7 +12,7 @@
       <p>This webpage does not seem to implement IAB Europe's Transparency and Consent Framework (this extension only works for websites using IAB Europe's TCF).</p>
     </div>
     <div id="cmplocator_found" class="hidden">
-      <p>A CMP on this webpage implements IAB Europe's Transparency and Consent Framework.<br />Waiting for an answer from CMP... (We may not get one before you close the cookie banner)</p>
+      <p>A CMP on this webpage implements IAB Europe's Transparency and Consent Framework.<br /><br />Waiting for an answer from CMP... (We may not get one before you close the cookie banner)</p>
     </div>
     <div id="gdpr_applies_false" class="hidden">
       <p>


### PR DESCRIPTION
### Summary

- refactor message passing between `uCookie.js` and `background.js`
   - previously, we had `uCookie.js` set up the port for `background.js` to connect to; this was problematic because `background.js` was handling messages from multiple content scripts that were activated. 
   - now, `background.js` _only connects to the active tab_ so it can tell `popup.js` the relevant tcdata for the active page

- set up `api.storage.local` for sharing information between `popup.js` and `background.js`
   - now, when `background.js` receives tcData, it'll store it in the local storage in the format of: `{ <activeTabId> : ...tcData }` for `popup.js` to read and update the UI accordingly

- current UI states we support in this branch:
    - if the `tcfApiLocator` was found or not
    - if `gdprApplies` or not
    - note: we also now successfully decode the consent string in `popup.js`, but still have to update the UI accordingly

### Reviewers
@charles-tan 

### Tests
locally on https://www.lemonde.fr/ and https://www.thetimes.co.uk/