### PR TITLE
[Issue #8] display purposes & consent

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -21,14 +21,22 @@ if (chrome === undefined) {
   api = chrome;
 }
 
+function hideElement(elementId) {
+  document.getElementById(elementId).classList.add('hidden');
+}
+
+function showHiddenElement(elementId) {
+  document.getElementById(elementId).classList.remove('hidden');
+}
+
 function handleCmpLocatorFound(cmpLocatorFound) {
   try {
     if (cmpLocatorFound === true) {
-      document.getElementById('nothing_found').classList.add('hidden');
-      document.getElementById('cmplocator_found').classList.remove('hidden');
+      hideElement('nothing_found');
+      showHiddenElement('cmplocator_found');
     } else {
-      document.getElementById('nothing_found').classList.remove('hidden');
-      document.getElementById('cmplocator_found').classList.add('hidden');
+      showHiddenElement('nothing_found');
+      hideElement('cmplocator_found');
     }
   } catch {
     // popup not open
@@ -38,11 +46,11 @@ function handleCmpLocatorFound(cmpLocatorFound) {
 function handleGdprApplies(gdprApplies) {
   try {
     if (gdprApplies === true) {
-      document.getElementById('gdpr_applies_false').classList.add('hidden');
-      document.getElementById('cmplocator_found').classList.remove('hidden');
+      hideElement('gdpr_applies_false');
+      showHiddenElement('cmplocator_found');
     } else {
-      document.getElementById('gdpr_applies_false').classList.remove('hidden');
-      document.getElementById('cmplocator_found').classList.add('hidden');
+      showHiddenElement('gdpr_applies_false');
+      hideElement('cmplocator_found');
     }
   } catch {
     // popup not open
@@ -72,6 +80,14 @@ function showNumVendors(vendorConsents) {
 
 function showPurposes(purposeConsents) {
   document.getElementById('nb_purposes').textContent = purposeConsents.set_.size;
+  [...Array(10).keys()].map((id) => {
+    if (purposeConsents.set_.has(id + 1)) {
+      document.getElementById(`purpose-${id + 1}`).classList.add('purpose-consented-item');
+      return true;
+    }
+    document.getElementById(`purpose-${id + 1}`).classList.add('purpose-not-consented-item');
+    return false;
+  });
 }
 
 function showTimestamps(createdAt, lastUpdated) {
@@ -102,15 +118,15 @@ function getActiveTabStorage() {
         return;
       }
 
-      if (data.gdprApplies !== undefined) {
+      if (data.gdprApplies !== undefined && data.found) {
         handleGdprApplies(data.gdprApplies);
       }
 
       // tcfapiLocator has been found & received tcString
       if (data.found === true && data.tcString !== undefined) {
         // no longer need to show found message
-        document.getElementById('cmplocator_found').classList.add('hidden');
-        document.getElementById('cmp_content').classList.remove('hidden');
+        hideElement('cmplocator_found');
+        showHiddenElement('cmp_content');
         showTCString(data.tcString);
 
         const decodedString = TCString.decode(data.tcString);
@@ -119,6 +135,20 @@ function getActiveTabStorage() {
       }
     });
   });
+}
+
+if (document.getElementById('show_purposes')) {
+  const purposesElement = document.getElementById('purposes_list');
+  const showPurposesButton = document.getElementById('show_purposes');
+  showPurposesButton.onclick = () => {
+    if (purposesElement.classList.contains('hidden')) {
+      showPurposesButton.innerText = 'Hide';
+      purposesElement.classList.remove('hidden');
+    } else {
+      showPurposesButton.innerText = 'Show purposes';
+      purposesElement.classList.add('hidden');
+    }
+  };
 }
 
 getActiveTabStorage();

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -65,6 +65,7 @@ function showCmp(cmpId) {
   if (cmpId in cmpListFull) {
     document.getElementById('cmpid').textContent = ` (ID: ${cmpId})`;
     document.getElementById('cmp').textContent = cmpListFull[cmpId];
+    document.getElementById('cmp').classList.add('identified_cmp');
   } else {
     document.getElementById('cmp').textContent = `Unknown CMP ID ${cmpId}. Search for it on the cmp-list: `;
     const a = document.createElement('a');

--- a/src/popup/ucookie.css
+++ b/src/popup/ucookie.css
@@ -1,5 +1,57 @@
 html, body {
-  width: 500px;
+  min-width: 500px;
+  font-size: 14px;
+}
+
+ol {
+  margin: 0;
+  padding-inline-start: 20px
+}
+
+h2 {
+  color:rgb(59, 56, 56);
+  font-size: 18px;
+  margin-top: 5px;
+  margin-bottom: 5px;
+  margin-left: 0px;
+}
+
+h3 {
+  font-size: 14px;
+  color:rgb(59, 56, 56);
+  font-weight: 600;
+  margin-top: 3px;
+  margin-bottom: 3px;
+}
+
+.total_nb_container{
+  margin-top: 14px;
+  margin-bottom: 14px;
+}
+
+.total_nb {
+  border: 1px solid rgb(7, 125, 141);
+  border-radius: 20%;
+  color: rgb(7, 125, 141);
+  padding: 6px;
+  font-size: 18px;
+}
+
+.content-container {
+  padding-bottom: 8px;
+  padding-top: 8px;
+  padding-left: 8px;
+  border-bottom: 1px solid rgb(204, 203, 203);
+}
+
+.purpose-consented-item {
+  list-style-type: "\2705";
+  margin-bottom: 6px;
+}
+
+.purpose-not-consented-item {
+  list-style-type: "\274C";
+  margin-bottom: 6px;
 }
 
 .hidden {
@@ -28,10 +80,15 @@ html, body {
 
 textarea {
   width: 480px;
+  margin-bottom: 5px;
 }
 
 #nb_purposes, #nb_vendors, #cmp {
     font-weight: bold;
+}
+
+#purposes_list {
+  margin-top: 5px;
 }
 
 #vendors {

--- a/src/popup/ucookie.css
+++ b/src/popup/ucookie.css
@@ -83,6 +83,11 @@ textarea {
   margin-bottom: 5px;
 }
 
+.identified_cmp {
+  color: rgb(6, 103, 116);
+  font-size: 16px;
+}
+
 #nb_purposes, #nb_vendors, #cmp {
     font-weight: bold;
 }

--- a/src/popup/ucookie.html
+++ b/src/popup/ucookie.html
@@ -23,17 +23,45 @@
       </p>
     </div>
     <div id="cmp_content" class="hidden">
-      The consent string registered by the CMP on this page contains the following information:<br />
-      CMP: <span id='cmp'></span><span id='cmpid'></span><br />
-      Number of vendors you consented to: <span id='nb_vendors'></span> <button id="show_vendors">Show</button><br />
-      Number of purposes of data processing you consented to: <span id='nb_purposes'></span><br />
-      Purposes of data processing you consented to: <span id='purposes'></span><br />
-      <br />
-      <span id="manual_cs" class="hidden">User-provided consent string.<br /></span>
-      <span id="show_cs">Consent string stored by CMP:<br /><textarea rows='5' id='consent_string'></textarea></span>
-      <br />
-      Created: <span id='created'></span><br />
-      Last Updated: <span id='last_updated'></span><br />
+      <!-- <div>The consent string registered by the CMP on this page contains the following information:</div> -->
+
+      <div class="content-container">CMP: <span id='cmp'></span><span id='cmpid'></span></div>
+      <div class="content-container">
+        <h2>Vendors</h2>
+        <div class="total_nb_container">
+          <span id='nb_vendors' class="total_nb"></span> total vendors consented to
+          <button id="show_vendors">Show vendors</button>
+        </div>
+      </div>
+      <div class="content-container">
+        <h2>Purposes</h2>
+        <div class="total_nb_container">
+          <span><span id='nb_purposes' class="total_nb"></span> / 10 purposes with consent</span>
+          <button id="show_purposes" class="show_button">Show purposes</button>
+        </div>
+        
+        <div class="hidden" id="purposes_list">
+          <ol>
+            <li id='purpose-1'><strong>&nbsp;Store and/or access information on a device:</strong> Cookies, device identifiers, or other information can be stored or accessed on your device for the purposes presented to you.</li>
+            <li id='purpose-2'><strong>&nbsp;Select basic ads:</strong> Ads can be shown to you based on the content you’re viewing, the app you’re using, your approximate location, or your device type.</li>
+            <li id='purpose-3'><strong>&nbsp;Create a personalised content profile:</strong> A profile can be built about you and your interests to show you personalised ads that are relevant to you.</li>
+            <li id='purpose-4'><strong>&nbsp;Select personalised ads:</strong> Personalised ads can be shown to you based on a profile about you ads that are relevant to you.</li>
+            <li id='purpose-5'><strong>&nbsp;Create a personalised content profile:</strong> A profile can be built about you and your interests to show you personalised content that is relevant to you.</li>
+            <li id='purpose-6'><strong>&nbsp;Select personalised content:</strong> Personalised content can be shown to you based on a profile about you.</li>
+            <li id='purpose-7'><strong>&nbsp;Measure ad performance:</strong> The performance and effectiveness of ads that you see or interact with can be measured.</li>
+            <li id='purpose-8'><strong>&nbsp;Measure content performance:</strong> The performance and effectiveness of content that you see or interact with can be measured. be measured.</li>
+            <li id='purpose-9'><strong>&nbsp;Apply market research to generate audience insights:</strong> Market research can be used to learn more about the audiences who visit sites/apps and view ads.</li>
+            <li id='purpose-10'><strong>&nbsp;Develop and improve products:</strong> Your data can be used to improve existing systems and software, and to develop new products.</li>
+          </ol>
+          <i>Read more about the <a href="https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/">TCF policies</a></i>
+        </div>
+      </div>
+      <div class="content-container">
+        <span id="manual_cs" class="hidden">User-provided consent string.<br /></span>
+        <span id="show_cs">Consent string stored by CMP:<br /><br /><textarea rows='5' id='consent_string'></textarea></span>
+        Created: <i><span id='created'></span></i><br />
+        Last Updated: <i><span id='last_updated'></span></i><br />
+      </div>
       <span id='vendors' class="hidden"></span>
     </div>
     <br />

--- a/src/popup/ucookie.html
+++ b/src/popup/ucookie.html
@@ -23,13 +23,13 @@
       </p>
     </div>
     <div id="cmp_content" class="hidden">
-      <!-- <div>The consent string registered by the CMP on this page contains the following information:</div> -->
+      <div><i>The consent string registered by the CMP on this page contains the following information.</i></div>
 
       <div class="content-container">CMP: <span id='cmp'></span><span id='cmpid'></span></div>
       <div class="content-container">
         <h2>Vendors</h2>
         <div class="total_nb_container">
-          <span id='nb_vendors' class="total_nb"></span> total vendors consented to
+          <span id='nb_vendors' class="total_nb"></span> total vendors consented to.
           <button id="show_vendors">Show vendors</button>
         </div>
       </div>


### PR DESCRIPTION
Addresses #8 

### summary
- update `popup.html` with new purposes for TCFv2
- add dynamic updates to show which purposes the user has consented to
- add some styling to make the popup more readable

### testing
locally

with unknown cmp:
<img width="536" alt="Screen Shot 2021-11-13 at 5 24 26 PM" src="https://user-images.githubusercontent.com/16495787/141660757-fab11477-decf-4467-812e-ea12d9c9f992.png">

with known cmp:
<img width="535" alt="Screen Shot 2021-11-13 at 5 24 33 PM" src="https://user-images.githubusercontent.com/16495787/141660762-6e42ce04-8d02-4353-9a5f-bcc6dabfdf30.png">
