### PR TITLE
Support reloading and improve local storage

### DIFF
--- a/src/content_scripts/uCookie.js
+++ b/src/content_scripts/uCookie.js
@@ -105,7 +105,7 @@ let backgroundPort;
 function handleMessage(message) {
   switch (message.message) {
     case LOOKING_FOR_LOCATOR_MSG:
-      console.log('Found CMP frame?', foundCmpFrame ? FOUND_MSG : NOT_FOUND_MSG);
+      console.log('CMP frame', foundCmpFrame ? FOUND_MSG : NOT_FOUND_MSG);
       backgroundPort.postMessage({
         response: foundCmpFrame ? FOUND_MSG : NOT_FOUND_MSG,
       });

--- a/src/content_scripts/uCookie.js
+++ b/src/content_scripts/uCookie.js
@@ -105,6 +105,7 @@ let backgroundPort;
 function handleMessage(message) {
   switch (message.message) {
     case LOOKING_FOR_LOCATOR_MSG:
+      console.log('Found CMP frame?', foundCmpFrame ? FOUND_MSG : NOT_FOUND_MSG);
       backgroundPort.postMessage({
         response: foundCmpFrame ? FOUND_MSG : NOT_FOUND_MSG,
       });
@@ -135,3 +136,5 @@ api.runtime.onConnect.addListener((port) => {
   backgroundPort = port;
   backgroundPort.onMessage.addListener(handleMessage);
 });
+
+// on page load

--- a/src/content_scripts/uCookie.js
+++ b/src/content_scripts/uCookie.js
@@ -136,5 +136,3 @@ api.runtime.onConnect.addListener((port) => {
   backgroundPort = port;
   backgroundPort.onMessage.addListener(handleMessage);
 });
-
-// on page load

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -37,7 +37,7 @@ function handleMessageFromUCookie(message, port, activeTabId) {
             tcfapiLocatorFound: false,
             gdprApplies: false,
             tcString: undefined,
-            timestamp: Date.now(),
+            timestampTcDataLoaded: Date.now(),
           },
         });
         break;
@@ -54,7 +54,7 @@ function handleMessageFromUCookie(message, port, activeTabId) {
             tcfapiLocatorFound: true,
             gdprApplies: message.data.tcData.gdprApplies,
             tcString: message.data.tcData.tcString,
-            timestamp: Date.now(),
+            timestampTcDataLoaded: Date.now(),
           },
         });
         break;

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -34,9 +34,10 @@ function handleMessageFromUCookie(message, port, activeTabId) {
         api.storage.local.set({
           [activeTabId]:
           {
-            found: false,
+            tcfapiLocatorFound: false,
             gdprApplies: false,
             tcString: undefined,
+            timestamp: Date.now(),
           },
         });
         break;
@@ -47,14 +48,13 @@ function handleMessageFromUCookie(message, port, activeTabId) {
         break;
       case GET_TC_DATA_CALL:
         console.log('received tcData!', message);
-
-        // TODO(ctan): add timestamp so we know when last updated
         api.storage.local.set({
           [activeTabId]:
           {
-            found: true,
+            tcfapiLocatorFound: true,
             gdprApplies: message.data.tcData.gdprApplies,
             tcString: message.data.tcData.tcString,
+            timestamp: Date.now(),
           },
         });
         break;
@@ -67,7 +67,6 @@ function handleMessageFromUCookie(message, port, activeTabId) {
 }
 
 function handleDisconnect(port) {
-  // TODO: show an error to the user if the port was disconnected
   console.log('[background.js] Port was closed', port.name);
 }
 
@@ -75,6 +74,11 @@ let contentScriptPort;
 api.storage.local.clear();
 
 function setUpConnection() {
+  if (contentScriptPort) {
+    console.log('disconnecting port', contentScriptPort);
+    contentScriptPort.disconnect();
+    contentScriptPort = undefined;
+  }
   api.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     // set up a connection with the active tab's content script (uCookie)
     const activeTabId = tabs[0].id;
@@ -94,13 +98,15 @@ function setUpConnection() {
 }
 
 api.tabs.onActivated.addListener(() => {
-  if (contentScriptPort) {
-    console.log('disconnecting port', contentScriptPort);
-    contentScriptPort.disconnect();
-  }
-
   setUpConnection();
 });
 
 // TODO: reset connection when page refreshes (i.e. uCookie gets refreshes)
-setUpConnection();
+
+chrome.webNavigation.onCommitted.addListener((details) => {
+  if (['reload', 'link', 'typed', 'generated'].includes(details.transitionType)) {
+    if (details.frameId === 0) {
+      setTimeout(() => { console.log('page reloaded, setting up uCookie connection'); setUpConnection(); }, 1000);
+    }
+  }
+});

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9,6 +9,7 @@
     "permissions": [
         "activeTab",
         "storage",
+        "webNavigation",
         "https://vendor-list.consensu.org/v*/vendor-list.json"
     ],
 

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -192,7 +192,7 @@ function getActiveTabStorage() {
  */
 function pruneTabStorage() {
   chrome.storage.local.get(null, (result) => {
-    console.log('FOOBAR', result);
+    console.log('Pruning local tabs storage');
     const keys = Object.keys(result);
     if (keys.length > 200) {
       keys.map((key) => {

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -124,11 +124,11 @@ function showTimestamps(createdAt, lastUpdated, lastFetched) {
   document.getElementById('last_fetched').textContent = formatIntlDate(lastFetched);
 }
 
-function handleTCData(data, timestamp) {
+function handleTCData(data, timestampTcDataLoaded) {
   showCmp(data.cmpId_);
   showNumVendors(data.vendorConsents);
   showPurposes(data.purposeConsents);
-  showTimestamps(data.created, data.lastUpdated, timestamp);
+  showTimestamps(data.created, data.lastUpdated, timestampTcDataLoaded);
 }
 
 function getActiveTabStorage() {
@@ -175,7 +175,7 @@ function getActiveTabStorage() {
 
           const decodedString = TCString.decode(data.tcString);
           console.log('decoded string', decodedString);
-          handleTCData(decodedString, data.timestamp);
+          handleTCData(decodedString, data.timestampTcDataLoaded);
         }
       });
       return true;

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -23,6 +23,7 @@ if (chrome === undefined) {
 }
 
 const tz = Intl.DateTimeFormat().resolvedOptions().locale;
+const CHECK_TAB_STORAGE_RETRIES = 3;
 
 function hideElement(elementId) {
   document.getElementById(elementId).classList.add('hidden');
@@ -132,7 +133,6 @@ function handleTCData(data, timestamp) {
 
 function getActiveTabStorage() {
   let count = 0;
-  const retries = 3;
   function loop() {
     count += 1;
     api.tabs.query({ active: true, currentWindow: true }, (tabs) => {
@@ -143,10 +143,10 @@ function getActiveTabStorage() {
         const data = result[activeTabId];
         console.log('data from storage', data);
         if (data === undefined) {
-          if (count <= retries) {
+          if (count <= CHECK_TAB_STORAGE_RETRIES) {
             document.getElementById('nothing_found').classList.add('hidden');
             document.getElementById('error_fetching_retry').classList.remove('hidden');
-            setTimeout(() => { console.log(`Could not find TCF data in local storage, try ${count}/${retries}`); loop(); }, 1000);
+            setTimeout(() => { console.log(`Could not find TCF data in local storage, try ${count}/${CHECK_TAB_STORAGE_RETRIES}`); loop(); }, 1000);
           } else {
             document.getElementById('nothing_found').classList.add('hidden');
             document.getElementById('error_fetching_retry').classList.add('hidden');
@@ -278,8 +278,8 @@ function handleResponseFromUCookieJs(message) {
     cmpLocatorFound = true;
     fetchData();
     try {
-      document.getElementById('nothing_found').classList.add('hidden');
-      document.getElementById('cmplocator_found').classList.remove('hidden');
+      hideElement('nothing_found');
+      showHiddenElement('cmplocator_found');
     } catch {
       // popup not open
     }

--- a/src/popup/ucookie.html
+++ b/src/popup/ucookie.html
@@ -11,6 +11,12 @@
     <div id="nothing_found">
       <p>This webpage does not seem to implement IAB Europe's Transparency and Consent Framework (this extension only works for websites using IAB Europe's TCF).</p>
     </div>
+    <div id="error_fetching_retry" class = "hidden">
+      <p>There has been some issue with the TCF Framework. We were not able to check this webpage. Retrying...</p>
+    </div>
+    <div id="error_fetching" class = "hidden">
+      <p>There has been some issue with the TCF Framework. We were not able to check this webpage. Please try again later.</p>
+    </div>
     <div id="cmplocator_found" class="hidden">
       <p>A CMP on this webpage implements IAB Europe's Transparency and Consent Framework.<br /><br />Waiting for an answer from CMP... (We may not get one before you close the cookie banner)</p>
     </div>
@@ -32,8 +38,9 @@
       <span id="manual_cs" class="hidden">User-provided consent string.<br /></span>
       <span id="show_cs">Consent string stored by CMP:<br /><textarea rows='5' id='consent_string'></textarea></span>
       <br />
-      Created: <span id='created'></span><br />
-      Last Updated: <span id='last_updated'></span><br />
+      TCF String Created: <span id='created'></span><br />
+      TCF String Last Updated: <span id='last_updated'></span><br />
+      TCF String Last Fetched: <span id='last_fetched'></span><br />
       <span id='vendors' class="hidden"></span>
     </div>
     <br />


### PR DESCRIPTION
Added a timestamp field to local storage so we know when the TC string was last fetched. Then added this to the popup UI.

Also added a function to prune the local tab storage when the cookie glasses popup is activated. It checks if there are over 200 items in local storage map and if there are, remove any that are related to uCookie and are older than 12 hours.

Added support for reloading a page. Now when pages are loaded, a connection between background script and uCookie script is attempted.

Looks to address https://github.com/katie-ta/Cookie-Glasses/issues/18 and https://github.com/katie-ta/Cookie-Glasses/issues/19