### PR TITLE
add support for manual TC string decoding and fix some bugs

### DIFF
--- a/src/js/vendorUtils.js
+++ b/src/js/vendorUtils.js
@@ -44,7 +44,7 @@ function showVendors(vendorList, allowedVendorIds, forPurposes, forceUpdate) {
   });
 }
 
-function fetchVendorList(vendorListVersion, allowedVendors) {
+function fetchVendorList(vendorListVersion, allowedVendors, forPurposes, forceUpdate) {
   const req = new Request(`https://vendor-list.consensu.org/v${vendorListVersion}/vendor-list.json`, {
     method: 'GET',
     headers: { Accept: 'application/json' },
@@ -56,23 +56,25 @@ function fetchVendorList(vendorListVersion, allowedVendors) {
     const a = {};
     a[`vendorList_${vendorListVersion}`] = data;
     api.storage.local.set(a);
-    showVendors(data, allowedVendors);
+    showVendors(data, allowedVendors, forPurposes, forceUpdate);
   }).catch((error) => {
     console.log('Error fetching vendor list: ', error);
     // TODO: surface generic error message in pop-up
   });
 }
 
-function loadVendors(vendorConsents, vendorListVersion, forPurposes, forceUpdate) {
+function loadVendors(
+  vendorConsents, vendorListVersion, vendorsContainerElement, forPurposes, forceUpdate,
+) {
   const allowedVendors = vendorConsents.set_;
   const vendorListName = `vendorList_${vendorListVersion}`;
   api.storage.local.get([`vendorList_${vendorListVersion}`], (result) => {
     if (result[vendorListName] === undefined) {
       // vendorList is not in localstorage, load it from IAB's website
-      document.getElementById('vendors_container').appendChild(document.createTextNode('Loading vendor list...'));
-      fetchVendorList(vendorListVersion, allowedVendors);
+      vendorsContainerElement.appendChild(document.createTextNode('Loading vendor list...'));
+      fetchVendorList(vendorListVersion, allowedVendors, forPurposes, forceUpdate);
     } else {
-      // vendorList is in locals storage
+      // vendorList is in local storage
       showVendors(result[vendorListName], allowedVendors, forPurposes, forceUpdate);
     }
   });
@@ -90,7 +92,8 @@ export default function handleVendors(vendorConsents, vendorListVersion, forCons
     showVendorsButton.onclick = () => {
       if (vendorsContainerElement.classList.contains('hidden')) {
         vendorsContainerElement.classList.remove('hidden');
-        loadVendors(vendorConsents, vendorListVersion, forConsent, forceUpdate);
+        loadVendors(vendorConsents, vendorListVersion, vendorsContainerElement,
+          forConsent, forceUpdate);
         showVendorsButton.innerText = 'Hide';
         showVendorsButton.classList.add('button_hide');
 

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -190,7 +190,6 @@ function showTimestamps(createdAt, lastUpdated, lastFetched) {
 }
 
 function handleTCData(data, timestampTcDataLoaded) {
-  // TODO(@ctan): use a force update when user manually decodes consent string
   const forceUpdate = timestampTcDataLoaded === undefined;
   showCmp(data.cmpId_);
   showNumVendors(data.vendorConsents);
@@ -302,36 +301,34 @@ if (document.getElementById('decode_cs')) {
   };
 }
 
-pruneTabStorage();
-getActiveTabStorage();
-
-// ----------------------------- OLD LOGIC -----------------------------
-
 if (document.getElementById('open_decoder')) {
-  document.getElementById('open_decoder').onclick = function (e) {
+  document.getElementById('open_decoder').onclick = (e) => {
     e.preventDefault();
-    const decoder = document.getElementById('decoder');
-    if (decoder.classList.contains('hidden')) {
-      decoder.classList.remove('hidden');
-      document.getElementById('details').classList.add('hidden');
+    if (document.getElementById('decoder').classList.contains('hidden')) {
+      showHiddenElement('decoder');
+      hideElement('details');
     } else {
-      decoder.classList.add('hidden');
+      hideElement('decoder');
     }
   };
 }
 
 if (document.getElementById('open_details')) {
-  document.getElementById('open_details').onclick = function (e) {
+  document.getElementById('open_details').onclick = (e) => {
     e.preventDefault();
-    const details = document.getElementById('details');
-    if (details.classList.contains('hidden')) {
-      details.classList.remove('hidden');
-      document.getElementById('decoder').classList.add('hidden');
+    if (document.getElementById('details').classList.contains('hidden')) {
+      showHiddenElement('details');
+      hideElement('decoder');
     } else {
-      details.classList.add('hidden');
+      hideElement('details');
     }
   };
 }
+
+pruneTabStorage();
+getActiveTabStorage();
+
+// ----------------------------- OLD LOGIC -----------------------------
 
 // https://bugzilla.mozilla.org/show_bug.cgi?id=1425829#c12
 async function firefoxWorkaroundForBlankPanel() {

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -293,11 +293,11 @@ if (document.getElementById('decode_cs')) {
       const decodedString = TCString.decode(rawConsentString);
       // update_with_consent_string_data(consentString);
       handleTCData(decodedString, undefined);
-      document.getElementById('show_cs').classList.add('hidden');
-      document.getElementById('manual_cs').classList.remove('hidden');
-      document.getElementById('decode_cs_error').classList.add('hidden');
+      hideElement('show_cs');
+      hideElement('decode_cs_error');
+      showHiddenElement('warning_header');
     } catch {
-      document.getElementById('decode_cs_error').classList.remove('hidden');
+      showHiddenElement('decode_cs_error');
     }
   };
 }

--- a/src/popup/ucookie.css
+++ b/src/popup/ucookie.css
@@ -47,6 +47,13 @@ button:hover {
   align-items:flex-end;
 }
 
+.warning_header {
+  color: rgb(8, 7, 7);
+  padding: 10px;
+  display: flex;
+  align-items:flex-end;
+}
+
 .cookie_glasses_title {
   font-size: 14px;
   margin-right: 0;

--- a/src/popup/ucookie.html
+++ b/src/popup/ucookie.html
@@ -39,7 +39,8 @@
         <div class="content-container">
           <div class="cmp_name_container">
             <div class="cmp_decorator">CMP</div>
-            <div id='cmp'></span><span id='cmpid'></div>
+            <div id='cmp'></div>
+            <div id='cmpid'></div>
           </div>
         </div>
         <div class="content-container">
@@ -70,7 +71,7 @@
             <i>Read more about the <a href="https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/" target="_blank">TCF policies</a></i>
           </div>
           <div id="consents_vendors_container" class="hidden bounded_container">
-            [*] indicates that vendors relies on only on legitimates interests
+            [*] indicates that vendors relies only on legitimates interests
             <ul id="purpose_vendors_list"></ul>
           </div>
         </div>
@@ -117,10 +118,10 @@
       <a href="#" id="open_decoder" title="Open manual consent string decoder"><img src="img/Octicons-tools.png" class="icon"></a>
       <a href="#" id="open_details" title="Open explanations about the icon's color scheme"><img src="img/question_mark.svg" class="icon"></a>
       <div class="hidden" id="decoder">
-        Manually decode a consent string:
+        Manually decode a consent string:<br />
         <input type="text" id="cs_to_decode" />
-        <button id="decode_cs">Decode</button>
-        <span id="decode_cs_error" class="hidden">Error: Invalid consent string</span>
+        <button id="decode_cs">Decode</button><br />
+        <i><span id="decode_cs_error" class="hidden">Error: Invalid consent string</span></i>
       </div>
       <div class="hidden" id="details">
         Icon color scheme:<br />

--- a/src/popup/ucookie.html
+++ b/src/popup/ucookie.html
@@ -9,10 +9,14 @@
   <body>
     <header role="banner" class="header">
       <div class="cookie_glasses_title">
-        <!-- <img src="../button/38.png" class="icon"> -->
         Cookie Glasses &#127850; &#129400; 
       </div>
     </header>
+    <div role="banner" class="warning_header hidden" id="warning_header">
+      <div class="cookie_glasses_manual_warning">
+        &#128227; Heads up! The below information was loaded from manually decoding a consent string
+      </div>
+    </div>
     <div class="main_content">
       <div id="nothing_found">
         <p>This webpage does not seem to implement IAB Europe's Transparency and Consent Framework (this extension only works for websites using IAB Europe's TCF).</p>
@@ -107,7 +111,6 @@
           </div>
         </div>
         <div class="content-container">
-          <span id="manual_cs" class="hidden">User-provided consent string.<br /></span>
           <span id="show_cs">Consent string stored by CMP:<br /><br /><textarea rows='5' id='consent_string'></textarea></span>
           TCF String Created: <i><span id='created'></span></i><br />
           TCF String Last Updated: <i><span id='last_updated'></span></i><br />


### PR DESCRIPTION
Fixes some bugs. Tested it with https://www.lemonde.fr/ and https://www.thetimes.co.uk/ on French VPN.

Bugs fixed:
1. Allows updates to UI based on a manually entered TC string (this is old functionality https://github.com/katie-ta/Cookie-Glasses/issues/26)
2. Related to 1, there was a html bug with cmpId
3. Fixes showVendors buttons that weren't showing vendors in UI
4. Related to 3, there was also a bug where showVendors for purposes wasn't loading right away