### PR TITLE
[#28] update icon color

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -3,16 +3,16 @@
 /* eslint-disable guard-for-in */
 /* global chrome */
 /* global browser */
+import { TCString } from '@iabtcf/core';
 import './img/Octicons-tools.png';
 import './img/question_mark.svg';
-import '../button/19_green.png';
-import '../button/19_red.png';
+import green19 from '../button/19_green.png';
+import green38 from '../button/38_green.png';
+import red19 from '../button/19_red.png';
+import red38 from '../button/38_red.png';
 import '../button/19.png';
-import '../button/38_green.png';
-import '../button/38_red.png';
 import '../button/38.png';
 import './ucookie.css';
-import { TCString } from '@iabtcf/core';
 import handleVendors from '../js/vendorUtils';
 
 const cmpListFull = require('../scripts/cmp_list_full.json');
@@ -82,12 +82,36 @@ function showCmp(cmpId) {
   }
 }
 
-function showNumVendors(vendorConsents) {
-  document.getElementById('nb_vendors').textContent = vendorConsents.set_.size;
+function setIcon(numPurposeConsents, numPurposeVendors, tabId) {
+  if (numPurposeVendors * numPurposeConsents === 0) {
+    api.browserAction.setIcon({
+      tabId,
+      path: {
+        19: green19,
+        38: green38,
+      },
+    });
+  } else {
+    api.browserAction.setIcon({
+      tabId,
+      path: {
+        19: red19,
+        38: red38,
+      },
+    });
+
+    api.browserAction.setBadgeText({
+      tabId,
+      text: (numPurposeConsents + numPurposeVendors).toString(),
+    });
+  }
 }
 
-function showPurposes(purposeConsents) {
+function handleConsents(purposeConsents, vendorConsents) {
+  // update totals
+  document.getElementById('nb_consent_vendors').textContent = vendorConsents.set_.size;
   document.getElementById('nb_purposes').textContent = purposeConsents.set_.size;
+
   [...Array(10).keys()].map((id) => {
     if (purposeConsents.set_.has(id + 1)) {
       document.getElementById(`purpose-${id + 1}`).classList.add('purpose-consented-item');
@@ -189,17 +213,23 @@ function showTimestamps(createdAt, lastUpdated, lastFetched) {
   }
 }
 
-function handleTCData(data, timestampTcDataLoaded) {
+function handleTCData(data, timestampTcDataLoaded, tabId) {
   const forceUpdate = timestampTcDataLoaded === undefined;
   showCmp(data.cmpId_);
-  showNumVendors(data.vendorConsents);
-  showPurposes(data.purposeConsents);
   showTimestamps(data.created, data.lastUpdated, timestampTcDataLoaded);
 
   // handle vendor buttons
   handleVendors(data.vendorConsents, VENDOR_LIST_VERSION, true, forceUpdate);
   handleVendors(data.vendorLegitimateInterests, VENDOR_LIST_VERSION, false, forceUpdate);
+
+  // show consents
+  handleConsents(data.purposeConsents, data.vendorConsents);
+
+  // show legitimate interests
   handleLegitimateInterests(data.purposeLegitimateInterests, data.vendorLegitimateInterests);
+
+  // set icon based on number of purposes
+  setIcon(data.purposeConsents.set_.size, data.purposeLegitimateInterests.set_.size, tabId);
 }
 
 function getActiveTabStorage() {
@@ -249,7 +279,7 @@ function getActiveTabStorage() {
 
           const decodedString = TCString.decode(data.tcString);
           console.log('decoded string', decodedString);
-          handleTCData(decodedString, data.timestampTcDataLoaded);
+          handleTCData(decodedString, data.timestampTcDataLoaded, activeTabId);
         }
         return true;
       });

--- a/src/popup/ucookie.css
+++ b/src/popup/ucookie.css
@@ -217,4 +217,25 @@ button:hover {
 
 #version {
     font-size: 0.8em;
+    margin-top: 8px;
+    text-align: right;
+}
+
+#details {
+  margin-top: 5px;
+  padding: 8px;
+}
+
+#cs_to_decode {
+  margin-top: 8px;
+}
+
+#decoder {
+  margin-top: 5px;
+  padding: 8px;
+}
+
+#decode_cs_error {
+  margin-top: 5px;
+  margin-bottom: 5px;
 }

--- a/src/popup/ucookie.html
+++ b/src/popup/ucookie.html
@@ -62,7 +62,7 @@
               <button id="show_consents" class="show_button">Show purposes</button>
             </div>
             <div class="total_nb_container total_nb_vendors_container">
-              <div><div id='nb_vendors' class="total_nb total_nb_vendors">n/a</div> total vendors allowed </div>
+              <div><div id='nb_consent_vendors' class="total_nb total_nb_vendors">n/a</div> total vendors allowed </div>
               <button id="show_vendor_consents" class="show_button">Show vendors</button>
             </div>
           </div>

--- a/src/popup/ucookie.html
+++ b/src/popup/ucookie.html
@@ -127,26 +127,25 @@
       <br />
       <a href="#" id="open_decoder" title="Open manual consent string decoder"><img src="img/Octicons-tools.png" class="icon"></a>
       <a href="#" id="open_details" title="Open explanations about the icon's color scheme"><img src="img/question_mark.svg" class="icon"></a>
-      <div class="hidden" id="decoder">
-        Manually decode a consent string:<br />
+      <div class="hidden bounded_container" id="decoder">
+        <div id="decoder_title">Manually decode a consent string:</div>
+        <div id="decode_cs_error" class="hidden">&#128680; <i><b>Error:</b> Invalid consent string</i></div>
         <input type="text" id="cs_to_decode" />
         <button id="decode_cs">Decode</button><br />
-        <i><span id="decode_cs_error" class="hidden">Error: Invalid consent string</span></i>
       </div>
-      <div class="hidden" id="details">
-        Icon color scheme:<br />
-        - Red indicates that consent is still set for at least one vendor and one purpose.<br />
-        - Green indicates that consent is completely refused.<br />
-        Vendors (advertisers) are supposed to check that <b>both</b> purposes and their vendor identifier is allowed to perform tracking.<br />
-        The number shown in the icon is the number of allowed purposes.
+      <div class="hidden bounded_container" id="details">
+        <strong>Icon details</strong>
+        <ul>
+          <li>Red indicates that consent is still set for at least one vendor and one purpose.</li>
+          <li>Green indicates that consent is completely refused.</li>
+          <li>The number shown in the icon is the number of allowed purposes for both Consent and Legitimate Interests.</li>
+        </ul>
+        <strong>Note:</strong> Vendors (advertisers) are supposed to check that <i>both</i> purposes and their Vendor ID is allowed to perform tracking.
       </div>
       <div id="version">
         Cookie Glasses version: 1.1.10
       </div>
   </div>
-    <!-- <script src="IAB_CMP_list_full.js"></script>
-    <script src="lib.js"></script>
-    <script src="popup.js"></script> -->
   </body>
 
 </html>


### PR DESCRIPTION
#### summary
Addresses #28 

- update icon color based on # consents
- display number of purposes consented to (for both consents + legitimate interests)
- update styling for the info section
- update styling for the manual decode section

#### test
<img width="509" alt="Screen Shot 2021-11-29 at 10 59 51 PM" src="https://user-images.githubusercontent.com/16495787/143984396-e1d92a7c-619b-4026-b8e3-6b84d77bca53.png">

<img width="514" alt="Screen Shot 2021-11-29 at 11 05 57 PM" src="https://user-images.githubusercontent.com/16495787/143984407-5170f1bf-8534-4277-94cf-3da48df9018c.png">

@charles-tan 