### PR TITLE
merge the vendor lists

### DIFF
--- a/src/js/vendorUtils.js
+++ b/src/js/vendorUtils.js
@@ -41,6 +41,10 @@ function showVendors(vendorList, allowedVendorIds, purposeConsents, purposeLegit
       Array.from(publisherRestrictions.keys()).forEach((key) => {
         const publisherResVendor = publisherRestrictions.get(key);
         if (id in publisherResVendor) {
+          // restrictionType meaning:
+          // 0 Purpose Flatly Not Allowed by Publisher (regardless of Vendor declarations)
+          // 1 Require Consent (if Vendor has declared the Purpose IDs legal basis as Legitimate Interest and flexible)
+          // 2 Require Legitimate Interest (if Vendor has declared the Purpose IDs legal basis as Consent and flexible)
           const restrictionType = publisherResVendor.get(id);
           if (restrictionType === 0) {
             vendorPurposes = vendorPurposes.filter((val) => val !== key);

--- a/src/js/vendorUtils.js
+++ b/src/js/vendorUtils.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-restricted-syntax */
+/* eslint-disable max-len */
 /* eslint-disable no-underscore-dangle */
 /* global chrome */
 /* global browser */
@@ -13,38 +15,64 @@ function findVendor(id, vendorList) {
   return vendorList.vendors[id];
 }
 
-function showVendors(vendorList, allowedVendorIds, forPurposes, forceUpdate) {
+function showVendors(vendorList, allowedVendorIds, purposeConsents, purposeLegitimateInterests, publisherRestrictions, forPurposes, forceUpdate) {
   const vendorsListElement = document.getElementById(forPurposes ? 'purpose_vendors_list' : 'legitimate_interests_vendors_list');
   if (vendorsListElement.children.length > 0 && !forceUpdate) {
     // we already populated the list of vendors, so no need to update
     // unless we're forcing an update
     return;
   }
-
+  console.log('purposeConsents', purposeConsents);
+  console.log('purposeLegitimateInterests', purposeLegitimateInterests);
+  console.log('publisherRestrictions', publisherRestrictions);
   allowedVendorIds.forEach((id) => {
     const vendor = findVendor(id, vendorList);
     console.log('vendor: ', vendor);
-    let vendorName;
     if (vendor === undefined) {
-      vendorName = `{Incorrect vendor, ID ${id}}`;
+      console.log(`{Incorrect vendor, ID ${id}}`);
     } else {
-      vendorName = vendor.name;
+      const vendorName = vendor.name;
+      let vendorPurposes = vendor.purposes;
+      let vendorLegIntPurposes = vendor.legIntPurposes;
+      const vendorFlexiblePurposes = vendor.flexiblePurposes;
+      const vendorSpecialPurposes = vendor.specialPurposes;
+      const vendorUsesCookies = vendor.usesCookies;
+
+      Array.from(publisherRestrictions.keys()).forEach((key) => {
+        const publisherResVendor = publisherRestrictions.get(key);
+        if (id in publisherResVendor) {
+          const restrictionType = publisherResVendor.get(id);
+          if (restrictionType === 0) {
+            vendorPurposes = vendorPurposes.filter((val) => val !== key);
+            vendorLegIntPurposes = vendorLegIntPurposes.filter((val) => val !== key);
+          } else if (restrictionType === 1) {
+            vendorLegIntPurposes = vendorLegIntPurposes.filter((val) => val !== key);
+            if ((vendorFlexiblePurposes.includes(key)) && !(vendorPurposes.includes(key))) {
+              vendorPurposes.add(key);
+            }
+          } else if (restrictionType === 2) {
+            vendorPurposes = vendorPurposes.filter((val) => val !== key);
+          } else {
+            console.log('Error: Unkown restrictionType');
+          }
+        }
+      });
+
+      const validPurposes = [...purposeConsents].filter((value) => vendorPurposes.includes(value));
+      const validLegIntPurposes = [...purposeLegitimateInterests].filter((value) => vendorLegIntPurposes.includes(value));
       const listItem = document.createElement('li');
       const vendorLink = document.createElement('a');
       vendorLink.href = vendor.policyUrl;
       vendorLink.target = '_blank';
       vendorLink.innerText = vendorName;
 
-      if (vendor.purposes.length === 0) {
-        vendorName += ' [*]';
-      }
       listItem.appendChild(vendorLink);
       vendorsListElement.appendChild(listItem);
     }
   });
 }
 
-function fetchVendorList(vendorListVersion, allowedVendors, forPurposes, forceUpdate) {
+function fetchVendorList(vendorListVersion, purposeConsents, purposeLegitimateInterests, publisherRestrictions, allowedVendors, forPurposes, forceUpdate) {
   const req = new Request(`https://vendor-list.consensu.org/v${vendorListVersion}/vendor-list.json`, {
     method: 'GET',
     headers: { Accept: 'application/json' },
@@ -56,31 +84,41 @@ function fetchVendorList(vendorListVersion, allowedVendors, forPurposes, forceUp
     const a = {};
     a[`vendorList_${vendorListVersion}`] = data;
     api.storage.local.set(a);
-    showVendors(data, allowedVendors, forPurposes, forceUpdate);
+    showVendors(data, allowedVendors, purposeConsents, purposeLegitimateInterests, publisherRestrictions, forPurposes, forceUpdate);
   }).catch((error) => {
     console.log('Error fetching vendor list: ', error);
     // TODO: surface generic error message in pop-up
   });
 }
 
+function setUnion(setA, setB) {
+  const _union = new Set(setA);
+  for (const elem of setB) {
+    _union.add(elem);
+  }
+  return _union;
+}
+
 function loadVendors(
-  vendorConsents, vendorListVersion, vendorsContainerElement, forPurposes, forceUpdate,
+  tcData, vendorListVersion, vendorsContainerElement, forPurposes, forceUpdate,
 ) {
-  const allowedVendors = vendorConsents.set_;
+  const allowedVendors = setUnion(tcData.vendorConsents.set_, tcData.vendorLegitimateInterests.set_);
+  const purposeConsents = tcData.purposeConsents.set_;
+  const purposeLegitimateInterests = tcData.purposeLegitimateInterests.set_;
+  const publisherRestrictions = tcData.publisherRestrictions.map;
   const vendorListName = `vendorList_${vendorListVersion}`;
   api.storage.local.get([`vendorList_${vendorListVersion}`], (result) => {
     if (result[vendorListName] === undefined) {
       // vendorList is not in localstorage, load it from IAB's website
-      vendorsContainerElement.appendChild(document.createTextNode('Loading vendor list...'));
-      fetchVendorList(vendorListVersion, allowedVendors, forPurposes, forceUpdate);
+      fetchVendorList(vendorListVersion, purposeConsents, purposeLegitimateInterests, publisherRestrictions, allowedVendors, forPurposes, forceUpdate);
     } else {
       // vendorList is in local storage
-      showVendors(result[vendorListName], allowedVendors, forPurposes, forceUpdate);
+      showVendors(result[vendorListName], allowedVendors, purposeConsents, purposeLegitimateInterests, publisherRestrictions, forPurposes, forceUpdate);
     }
   });
 }
 
-export default function handleVendors(vendorConsents, vendorListVersion, forConsent, forceUpdate) {
+export default function handleVendors(tcData, vendorListVersion, forConsent, forceUpdate) {
   const buttonId = forConsent ? 'show_vendor_consents' : 'show_vendor_legitimate_interests';
   const containerId = forConsent ? 'consents_vendors_container' : 'legitimate_interests_vendors_container';
   const purposesListId = forConsent ? 'purposes_list' : 'legitimate_interests_list';
@@ -92,7 +130,7 @@ export default function handleVendors(vendorConsents, vendorListVersion, forCons
     showVendorsButton.onclick = () => {
       if (vendorsContainerElement.classList.contains('hidden')) {
         vendorsContainerElement.classList.remove('hidden');
-        loadVendors(vendorConsents, vendorListVersion, vendorsContainerElement,
+        loadVendors(tcData, vendorListVersion, vendorsContainerElement,
           forConsent, forceUpdate);
         showVendorsButton.innerText = 'Hide';
         showVendorsButton.classList.add('button_hide');

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -197,8 +197,8 @@ function handleTCData(data, timestampTcDataLoaded) {
   showTimestamps(data.created, data.lastUpdated, timestampTcDataLoaded);
 
   // handle vendor buttons
-  handleVendors(data.vendorConsents, VENDOR_LIST_VERSION, true, forceUpdate);
-  handleVendors(data.vendorLegitimateInterests, VENDOR_LIST_VERSION, false, forceUpdate);
+  handleVendors(data, VENDOR_LIST_VERSION, true, forceUpdate);
+  handleVendors(data, VENDOR_LIST_VERSION, false, forceUpdate);
   handleLegitimateInterests(data.purposeLegitimateInterests, data.vendorLegitimateInterests);
 }
 

--- a/src/popup/ucookie.html
+++ b/src/popup/ucookie.html
@@ -82,7 +82,6 @@
             <i>Read more about the <a href="https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/" target="_blank">TCF policies</a></i>
           </div>
           <div id="consents_vendors_container" class="hidden bounded_container">
-            [*] indicates that vendors relies only on legitimates interests
             <ul id="purpose_vendors_list"></ul>
           </div>
         </div>


### PR DESCRIPTION
A bit of a WIP. This merges the vendor lists into one so that we can display additional vendor info in the form of a table. It takes into account flexible purposes and publisher restrictions when deciding to show a vendor for which purposes/legitimate interests.