### PR TITLE
make table header sticky

### DIFF
--- a/src/popup/ucookie.css
+++ b/src/popup/ucookie.css
@@ -66,6 +66,14 @@ a:visited {
 
 thead {
   border-bottom: 1px solid rgb(182, 170, 132);
+  background-color: white;
+}
+
+th {
+  background-color: rgb(68, 85, 108);
+  color: white;
+  position: sticky;
+  top: 0;
 }
 
 .styled-table {

--- a/src/popup/ucookie.html
+++ b/src/popup/ucookie.html
@@ -87,11 +87,11 @@
               <table id="consent_purposes_list" class="styled-table">
                 <thead>
                   <tr>
-                    <td>ID</td>
-                    <td>Purpose</td>
-                    <td>Description</td>
-                    <td>Consent?</td>
-                    <td>Legit. Interest?</td>
+                    <th>ID</th>
+                    <th>Purpose</th>
+                    <th>Description</th>
+                    <th>Consent?</th>
+                    <th>Legit. Interest?</th>
                   </tr>
                   <tbody id="purpose_list_body">
                   </tbody>


### PR DESCRIPTION
### summary
Because the table length is so long, it's hard to keep track of which column is which when scrolling through. This change makes the table header sticky while scrolling.

### test
<img width="501" alt="Screen Shot 2021-12-05 at 9 27 38 PM" src="https://user-images.githubusercontent.com/16495787/144777439-dbf3b28d-659c-4b74-a1ec-7512a28421be.png">

