### PR TITLE
gdpr applies fix

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -172,7 +172,11 @@ function getActiveTabStorage() {
         }
 
         // tcfapiLocator has been found & received tcString
-        if (data.tcfapiLocatorFound === true && data.tcString !== undefined) {
+        // only update the extension if gdprApplies
+        if (data.tcfapiLocatorFound === true
+            && data.tcString !== undefined
+            && data.gdprApplies === true
+        ) {
           // no longer need to show found message or any fetching messages
           hideElement('nothing_found');
           hideElement('error_fetching');


### PR DESCRIPTION
### summary
Only update the extension with TC information if `gdprApplies` = true. 

### test
I was testing the extension on various sites, and found that https://matethelabel.com/ returns `gdprApplies = true` and `gdprApplies = false`, which leads to a confusing experience. This change only renders TC data information if the `gdprApplies = true`.